### PR TITLE
Improve blk processing performance

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wcgcyx/teler/backend"
 	"github.com/wcgcyx/teler/blockchain"
+	"github.com/wcgcyx/teler/worldstate"
 	"go.uber.org/mock/gomock"
 )
 
@@ -51,6 +52,7 @@ func TestNormalSync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m1 := backend.NewMockBackend(ctrl)
 	m2 := blockchain.NewMockBlockchain(ctrl)
+	m3 := worldstate.NewMockLayeredWorldStateArchive(ctrl)
 	m1.
 		EXPECT().
 		Blockchain().
@@ -83,6 +85,11 @@ func TestNormalSync(t *testing.T) {
 			return nil
 		}).
 		AnyTimes()
+	m1.
+		EXPECT().
+		StateArchive().
+		Return(m3).
+		AnyTimes()
 	m2.
 		EXPECT().
 		GetHead(gomock.Any()).
@@ -98,6 +105,26 @@ func TestNormalSync(t *testing.T) {
 			return res, nil
 		}).
 		AnyTimes()
+	m3.
+		EXPECT().
+		GetMaxLayerToRetain().
+		Return(uint64(256))
+	m3.
+		EXPECT().
+		GetPruningFrequency().
+		Return(uint64(127))
+	m3.
+		EXPECT().
+		SetMaxLayerToRetain(uint64(1))
+	m3.
+		EXPECT().
+		SetPruningFrequency(uint64(1))
+	m3.
+		EXPECT().
+		SetMaxLayerToRetain(uint64(256))
+	m3.
+		EXPECT().
+		SetPruningFrequency(uint64(127))
 
 	n, err := NewNode(Opts{
 		CheckFrequency:                    600 * time.Millisecond,

--- a/statestore/statestore_impl.go
+++ b/statestore/statestore_impl.go
@@ -157,7 +157,7 @@ func (s *stateStoreImpl) GetAccountValue(addr common.Address) (itypes.AccountVal
 		if !errors.Is(err, datastore.ErrNotFound) {
 			return itypes.AccountValue{}, err
 		}
-		log.Debugf("Get account value empty for %v", addr)
+		// log.Debugf("Get account value empty for %v", addr)
 		res.Nonce = 0
 		res.Balance = uint256.NewInt(0)
 		res.CodeHash = types.EmptyCodeHash
@@ -172,7 +172,7 @@ func (s *stateStoreImpl) GetAccountValue(addr common.Address) (itypes.AccountVal
 		}
 		res.Version = version
 	} else {
-		log.Debugf("Get account value non-empty for %v", addr)
+		// log.Debugf("Get account value non-empty for %v", addr)
 		raw, err := decodeAccountValue(val)
 		if err != nil {
 			return itypes.AccountValue{}, err
@@ -194,13 +194,13 @@ func (s *stateStoreImpl) GetStorageByVersion(addr common.Address, version uint64
 	val, err := s.ds.Get(ctx, getStorageKey(addr, version, key))
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
-			log.Debugf("Get storage empty for %v-%v-%v", addr, version, key)
+			// log.Debugf("Get storage empty for %v-%v-%v", addr, version, key)
 			return common.Hash{}, nil
 		}
 		return common.Hash{}, err
 	}
 
-	log.Debugf("Get storage non-empty for %v-%v-%v", addr, version, key)
+	// log.Debugf("Get storage non-empty for %v-%v-%v", addr, version, key)
 	return decodeStorage(val)
 }
 

--- a/worldstate/layeredstate_impl.go
+++ b/worldstate/layeredstate_impl.go
@@ -11,8 +11,6 @@ package worldstate
  */
 
 import (
-	"encoding/hex"
-
 	"github.com/ethereum/go-ethereum/common"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/wcgcyx/teler/statestore"
@@ -93,8 +91,8 @@ func newLayeredWorldState(
 
 // GetAccountValue gets the account value of given address.
 func (s *layeredStateImpl) GetAccountValue(addr common.Address, requireCache bool) (res itypes.AccountValue) {
-	log.Debugf("Layer %v - GetAccountValue(%v)", s.layerLog.RootHash, addr)
-	defer func() { log.Debugf("Layer %v - GetAccountValue(%v) returns (%v)", s.layerLog.RootHash, addr, res) }()
+	// log.Debugf("Layer %v - GetAccountValue(%v)", s.layerLog.RootHash, addr)
+	// defer func() { log.Debugf("Layer %v - GetAccountValue(%v) returns (%v)", s.layerLog.RootHash, addr, res) }()
 
 	var ok bool
 	res, ok = s.layerLog.UpdatedAccounts[addr]
@@ -112,10 +110,10 @@ func (s *layeredStateImpl) GetAccountValue(addr common.Address, requireCache boo
 
 // GetCodeByHash gets the code by code hash.
 func (s *layeredStateImpl) GetCodeByHash(codeHash common.Hash, requireCache bool) (code []byte) {
-	log.Debugf("Layer %v - GetCodeByHash(%v)", s.layerLog.RootHash, codeHash)
-	defer func() {
-		log.Debugf("Layer %v - GetCodeByHash(%v) returns %v", s.layerLog.RootHash, codeHash, hex.EncodeToString(code))
-	}()
+	// log.Debugf("Layer %v - GetCodeByHash(%v)", s.layerLog.RootHash, codeHash)
+	// defer func() {
+	// 	log.Debugf("Layer %v - GetCodeByHash(%v) returns %v", s.layerLog.RootHash, codeHash, hex.EncodeToString(code))
+	// }()
 
 	var ok bool
 	code, ok = s.layerLog.CodePreimage[codeHash]
@@ -133,10 +131,10 @@ func (s *layeredStateImpl) GetCodeByHash(codeHash common.Hash, requireCache bool
 
 // GetStorageByVersion gets storage by addr and version.
 func (s *layeredStateImpl) GetStorageByVersion(addr common.Address, version uint64, key common.Hash, requireCache bool) (val common.Hash) {
-	log.Debugf("Layer %v - GetStorageByVersion(%v, %v, %v)", s.layerLog.RootHash, addr, version, key)
-	defer func() {
-		log.Debugf("Layer %v - GetStorageByVersion(%v, %v, %v) returns %v", s.layerLog.RootHash, addr, version, key, val)
-	}()
+	// log.Debugf("Layer %v - GetStorageByVersion(%v, %v, %v)", s.layerLog.RootHash, addr, version, key)
+	// defer func() {
+	// 	log.Debugf("Layer %v - GetStorageByVersion(%v, %v, %v) returns %v", s.layerLog.RootHash, addr, version, key, val)
+	// }()
 
 	accountKey := itypes.GetAccountStorageKey(addr, version)
 	storage, ok := s.layerLog.UpdatedStorage[accountKey]

--- a/worldstate/mutableaccount_impl.go
+++ b/worldstate/mutableaccount_impl.go
@@ -80,8 +80,8 @@ func (acct *mutableAccountImpl) interpretVersion() uint64 {
 
 // Empty returns if this account is empty.
 func (acct *mutableAccountImpl) Empty() (empty bool) {
-	log.Debugf("Account %v - Empty()", acct.addr)
-	defer func() { log.Debugf("Account %v - Empty() returns %v", acct.addr, empty) }()
+	// log.Debugf("Account %v - Empty()", acct.addr)
+	// defer func() { log.Debugf("Account %v - Empty() returns %v", acct.addr, empty) }()
 
 	empty = acct.nonce == 0 &&
 		acct.balance.IsZero() &&
@@ -91,8 +91,8 @@ func (acct *mutableAccountImpl) Empty() (empty bool) {
 
 // Exist returns if this account exists.
 func (acct *mutableAccountImpl) Exists(isEIP158 bool) (exists bool) {
-	log.Debugf("Account %v - Exists()", acct.addr)
-	defer func() { log.Debugf("Account %v - Exists() returns %v", acct.addr, exists) }()
+	// log.Debugf("Account %v - Exists()", acct.addr)
+	// defer func() { log.Debugf("Account %v - Exists() returns %v", acct.addr, exists) }()
 
 	if acct.interpretVersion() == notExisted {
 		exists = false
@@ -139,8 +139,8 @@ func (acct *mutableAccountImpl) DirtyStorage() bool {
 
 // GetState returns the given storage slot value of this account.
 func (acct *mutableAccountImpl) GetState(key common.Hash) (res common.Hash) {
-	log.Debugf("Account %v - GetState(%v)", acct.addr, key)
-	defer func() { log.Debugf("Account %v - GetState(%v) returns %v", acct.addr, key, res) }()
+	// log.Debugf("Account %v - GetState(%v)", acct.addr, key)
+	// defer func() { log.Debugf("Account %v - GetState(%v) returns %v", acct.addr, key, res) }()
 
 	if !acct.dirtyStorage {
 		res = common.Hash{}
@@ -162,10 +162,10 @@ func (acct *mutableAccountImpl) GetState(key common.Hash) (res common.Hash) {
 
 // Create attempts to create this non-existence account.
 func (acct *mutableAccountImpl) Create() (revert func()) {
-	log.Debugf("Account %v - Create() [Before %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - Create() returns void [After %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - Create() [Before %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - Create() returns void [After %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	if acct.interpretVersion() == beingDeleted {
 		log.Panicf("Cannot create to overwrite account being deleted")
@@ -185,10 +185,10 @@ func (acct *mutableAccountImpl) Create() (revert func()) {
 
 // SetNonce attempts to set the nonce of this account.
 func (acct *mutableAccountImpl) SetNonce(nonce uint64) (revert func()) {
-	log.Debugf("Account %v - SetNonce(%v) [Before %v-%v-%v-%v-%v]", acct.addr, nonce, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - SetNonce(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, nonce, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - SetNonce(%v) [Before %v-%v-%v-%v-%v]", acct.addr, nonce, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - SetNonce(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, nonce, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	optionalRevert := func() {}
 	if acct.interpretVersion() == notExisted {
@@ -210,10 +210,10 @@ func (acct *mutableAccountImpl) SetNonce(nonce uint64) (revert func()) {
 
 // SetBalance attempts to set the balance of this account.
 func (acct *mutableAccountImpl) SetBalance(balance *uint256.Int) (revert func()) {
-	log.Debugf("Account %v - SetBalance(%v) [Before %v-%v-%v-%v-%v]", acct.addr, balance, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - SetBalance(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, balance, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - SetBalance(%v) [Before %v-%v-%v-%v-%v]", acct.addr, balance, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - SetBalance(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, balance, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	optionalRevert := func() {}
 	if acct.interpretVersion() == notExisted {
@@ -235,10 +235,10 @@ func (acct *mutableAccountImpl) SetBalance(balance *uint256.Int) (revert func())
 
 // SetCode attempts to set the code of this account.
 func (acct *mutableAccountImpl) SetCode(code []byte) (revert func()) {
-	log.Debugf("Account %v - SetCode(%v) [Before %v-%v-%v-%v-%v]", acct.addr, len(code), acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - SetCode(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, len(code), acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - SetCode(%v) [Before %v-%v-%v-%v-%v]", acct.addr, len(code), acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - SetCode(%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, len(code), acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	optionalRevert := func() {}
 	if acct.interpretVersion() == notExisted {
@@ -289,10 +289,10 @@ func (acct *mutableAccountImpl) SetCode(code []byte) (revert func()) {
 
 // SetState attempts to set the storage slot value of this account.
 func (acct *mutableAccountImpl) SetState(key common.Hash, val common.Hash) (revert func()) {
-	log.Debugf("Account %v - SetState(%v,%v) [Before %v-%v-%v-%v-%v]", acct.addr, key, val, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - SetState(%v,%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, key, val, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - SetState(%v,%v) [Before %v-%v-%v-%v-%v]", acct.addr, key, val, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - SetState(%v,%v) returns void [After %v-%v-%v-%v-%v]", acct.addr, key, val, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	optionalRevert := func() {}
 	if acct.interpretVersion() == notExisted {
@@ -329,8 +329,8 @@ func (acct *mutableAccountImpl) SetState(key common.Hash, val common.Hash) (reve
 
 // HasSelfDestructed checks if this account has been self destructed.
 func (acct *mutableAccountImpl) HasSelfDestructed() (res bool) {
-	log.Debugf("Account %v - HasSelfDestructed()", acct.addr)
-	defer func() { log.Debugf("Account %v - HasSelfDestructed() returns %v", acct.addr, res) }()
+	// log.Debugf("Account %v - HasSelfDestructed()", acct.addr)
+	// defer func() { log.Debugf("Account %v - HasSelfDestructed() returns %v", acct.addr, res) }()
 
 	res = acct.interpretVersion() == beingDeleted
 	return
@@ -338,10 +338,10 @@ func (acct *mutableAccountImpl) HasSelfDestructed() (res bool) {
 
 // SelfDestruct attempts to destruct this account.
 func (acct *mutableAccountImpl) SelfDestruct() (revert func()) {
-	log.Debugf("Account %v - SelfDestruct() [Before %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	defer func() {
-		log.Debugf("Account %v - SelfDestruct() returns void [After %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
-	}()
+	// log.Debugf("Account %v - SelfDestruct() [Before %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// defer func() {
+	// 	log.Debugf("Account %v - SelfDestruct() returns void [After %v-%v-%v-%v-%v]", acct.addr, acct.nonce, acct.balance, acct.codeHash, acct.dirtyStorage, acct.version)
+	// }()
 
 	if acct.interpretVersion() == beingDeleted {
 		// Account can be destructed again with no effect on the account state.

--- a/worldstate/mutablestate_impl.go
+++ b/worldstate/mutablestate_impl.go
@@ -11,7 +11,6 @@ package worldstate
  */
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -93,19 +92,19 @@ func (s *mutableStateImpl) SetLogger(l *tracing.Hooks) {
 
 // loadAccountValue for given address from dirty states or parent.
 func (s *mutableStateImpl) loadAccount(addr common.Address, write bool) (acct mutableAccount) {
-	log.Debugf("Mutable - loadAccount(%v, %v)", addr, write)
-	defer func() {
-		log.Debugf("Mutable - loadAccount(%v, %v) returns (%v-%v-%v-%v-%v)", addr, write, acct.Nonce(), acct.Balance(), acct.CodeHash(), acct.DirtyStorage(), acct.Version())
-	}()
+	// log.Debugf("Mutable - loadAccount(%v, %v)", addr, write)
+	// defer func() {
+	// 	log.Debugf("Mutable - loadAccount(%v, %v) returns (%v-%v-%v-%v-%v)", addr, write, acct.Nonce(), acct.Balance(), acct.CodeHash(), acct.DirtyStorage(), acct.Version())
+	// }()
 
 	// Check dirty first
 	var ok bool
 	acct, ok = s.DirtyAccounts[addr]
 	if !ok {
-		log.Debugf("Mutable - loadAccount(%v, %v), load from parent", addr, write)
+		// log.Debugf("Mutable - loadAccount(%v, %v), load from parent", addr, write)
 		acct = s.parent.GetMutableAccount(addr)
 		if write {
-			log.Debugf("Mutable - loadAccount(%v, %v), load to dirty accounts", addr, write)
+			// log.Debugf("Mutable - loadAccount(%v, %v), load to dirty accounts", addr, write)
 			s.DirtyAccounts[addr] = acct
 			s.recordJournal(func() { delete(s.DirtyAccounts, addr) })
 		}
@@ -125,8 +124,8 @@ func (s *mutableStateImpl) recordJournal(revert func()) {
 // Exist reports whether the given account address exists in the state.
 // Notably this also returns true for self-destructed accounts.
 func (s *mutableStateImpl) Exist(addr common.Address) (exists bool) {
-	log.Debugf("Mutable - Exist(%v)", addr)
-	defer func() { log.Debugf("Mutable - Exist(%v) returns %v", addr, exists) }()
+	// log.Debugf("Mutable - Exist(%v)", addr)
+	// defer func() { log.Debugf("Mutable - Exist(%v) returns %v", addr, exists) }()
 
 	acct := s.loadAccount(addr, false)
 	exists = acct.Exists(s.config.IsEIP158(big.NewInt(int64(s.newHeight))))
@@ -136,8 +135,8 @@ func (s *mutableStateImpl) Exist(addr common.Address) (exists bool) {
 // Empty returns whether the state object is either non-existent
 // or empty according to the EIP161 specification (balance = nonce = code = 0).
 func (s *mutableStateImpl) Empty(addr common.Address) (empty bool) {
-	log.Debugf("Mutable - Empty(%v)", addr)
-	defer func() { log.Debugf("Mutable - Empty(%v) returns %v", addr, empty) }()
+	// log.Debugf("Mutable - Empty(%v)", addr)
+	// defer func() { log.Debugf("Mutable - Empty(%v) returns %v", addr, empty) }()
 
 	acct := s.loadAccount(addr, false)
 	empty = acct.Empty()
@@ -146,8 +145,8 @@ func (s *mutableStateImpl) Empty(addr common.Address) (empty bool) {
 
 // GetBalance retrieves the balance from the given address or 0 if object not found.
 func (s *mutableStateImpl) GetBalance(addr common.Address) (balance *uint256.Int) {
-	log.Debugf("Mutable - GetBalance(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetBalance(%v) returns %v", addr, balance) }()
+	// log.Debugf("Mutable - GetBalance(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetBalance(%v) returns %v", addr, balance) }()
 
 	acct := s.loadAccount(addr, false)
 	balance = uint256.NewInt(0).Set(acct.Balance())
@@ -156,8 +155,8 @@ func (s *mutableStateImpl) GetBalance(addr common.Address) (balance *uint256.Int
 
 // GetNonce retrieves the nonce from the given address or 0 if object not found.
 func (s *mutableStateImpl) GetNonce(addr common.Address) (nonce uint64) {
-	log.Debugf("Mutable - GetNonce(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetNonce(%v) returns %v", addr, nonce) }()
+	// log.Debugf("Mutable - GetNonce(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetNonce(%v) returns %v", addr, nonce) }()
 
 	acct := s.loadAccount(addr, false)
 	nonce = acct.Nonce()
@@ -166,8 +165,8 @@ func (s *mutableStateImpl) GetNonce(addr common.Address) (nonce uint64) {
 
 // GetCodeHash gets the code hash of the given address.
 func (s *mutableStateImpl) GetCodeHash(addr common.Address) (codeHash common.Hash) {
-	log.Debugf("Mutable - GetCodeHash(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetCodeHash(%v) returns %v", addr, codeHash) }()
+	// log.Debugf("Mutable - GetCodeHash(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetCodeHash(%v) returns %v", addr, codeHash) }()
 
 	acct := s.loadAccount(addr, false)
 	codeHash = acct.CodeHash()
@@ -176,8 +175,8 @@ func (s *mutableStateImpl) GetCodeHash(addr common.Address) (codeHash common.Has
 
 // GetCode gets the code of the given address.
 func (s *mutableStateImpl) GetCode(addr common.Address) (code []byte) {
-	log.Debugf("Mutable - GetCode(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetCode(%v) returns %v", addr, hex.EncodeToString(code)) }()
+	// log.Debugf("Mutable - GetCode(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetCode(%v) returns %v", addr, hex.EncodeToString(code)) }()
 
 	acct := s.loadAccount(addr, false)
 	code = acct.Code()
@@ -186,8 +185,8 @@ func (s *mutableStateImpl) GetCode(addr common.Address) (code []byte) {
 
 // GetCodeSize gets the size of the code of the given address.
 func (s *mutableStateImpl) GetCodeSize(addr common.Address) (size int) {
-	log.Debugf("Mutable - GetCodeSize(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetCodeSize(%v) returns %v", addr, size) }()
+	// log.Debugf("Mutable - GetCodeSize(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetCodeSize(%v) returns %v", addr, size) }()
 
 	size = len(s.GetCode(addr))
 	return
@@ -196,8 +195,8 @@ func (s *mutableStateImpl) GetCodeSize(addr common.Address) (size int) {
 // GetStorageRoot retrieves the storage root from the given address or empty
 // if object not found.
 func (s *mutableStateImpl) GetStorageRoot(addr common.Address) (storageRoot common.Hash) {
-	log.Debugf("Mutable - GetStorageRoot(%v)", addr)
-	defer func() { log.Debugf("Mutable - GetStorageRoot(%v) returns %v", addr, storageRoot) }()
+	// log.Debugf("Mutable - GetStorageRoot(%v)", addr)
+	// defer func() { log.Debugf("Mutable - GetStorageRoot(%v) returns %v", addr, storageRoot) }()
 
 	acct := s.loadAccount(addr, false)
 	storageRoot = types.EmptyRootHash
@@ -210,8 +209,8 @@ func (s *mutableStateImpl) GetStorageRoot(addr common.Address) (storageRoot comm
 
 // GetState retrieves the value associated with the specific key.
 func (s *mutableStateImpl) GetState(addr common.Address, key common.Hash) (val common.Hash) {
-	log.Debugf("Mutable - GetState(%v, %v)", addr, key)
-	defer func() { log.Debugf("Mutable - GetState(%v, %v) returns %v", addr, key, val) }()
+	// log.Debugf("Mutable - GetState(%v, %v)", addr, key)
+	// defer func() { log.Debugf("Mutable - GetState(%v, %v) returns %v", addr, key, val) }()
 
 	acct := s.loadAccount(addr, false)
 	val = acct.GetState(key)
@@ -222,8 +221,8 @@ func (s *mutableStateImpl) GetState(addr common.Address, key common.Hash) (val c
 // used when the EVM emits new state logs. It should be invoked before
 // transaction execution.
 func (s *mutableStateImpl) SetTxContext(thash common.Hash, ti int) {
-	log.Debugf("Mutable - SetTxContext(%v, %v)", thash, ti)
-	defer func() { log.Debugf("Mutable - SetTxContext(%v, %v) returns void", thash, ti) }()
+	// log.Debugf("Mutable - SetTxContext(%v, %v)", thash, ti)
+	// defer func() { log.Debugf("Mutable - SetTxContext(%v, %v) returns void", thash, ti) }()
 
 	// Note: This does not involve a journal revert in the original geth source code
 	s.TxHash = thash
@@ -234,8 +233,8 @@ func (s *mutableStateImpl) SetTxContext(thash common.Hash, ti int) {
 
 // TxIndex returns the current transaction index set by Prepare.
 func (s *mutableStateImpl) TxIndex() (txID int) {
-	log.Debugf("Mutable - TxIndex()")
-	defer func() { log.Debugf("Mutable - TxIndex() returns %v", txID) }()
+	// log.Debugf("Mutable - TxIndex()")
+	// defer func() { log.Debugf("Mutable - TxIndex() returns %v", txID) }()
 
 	txID = s.TxIdx
 	return
@@ -255,15 +254,15 @@ func (s *mutableStateImpl) TxIndex() (txID int) {
 // - Add coinbase to access list (EIP-3651)
 // - Reset transient storage (EIP-1153)
 func (s *mutableStateImpl) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	log.Debugf("Mutable - Prepare(...)")
-	log.Debugf("ChainID:%v Homestead:%v EIP150:%v EIP155:%v EIP158:%v", rules.ChainID, rules.IsHomestead, rules.IsEIP150, rules.IsEIP155, rules.IsEIP158)
-	log.Debugf("EIP2929:%v EIP4762:%v", rules.IsEIP2929, rules.IsEIP4762)
-	log.Debugf("Byzantium:%v Constantinople:%v Petersburg:%v Istanbul:%v", rules.IsByzantium, rules.IsConstantinople, rules.IsPetersburg, rules.IsIstanbul)
-	log.Debugf("Berlin:%v London:%v", rules.IsBerlin, rules.IsLondon)
-	log.Debugf("Merge:%v Shanghai:%v Cancun:%v Prague:%v Verkle:%v", rules.IsMerge, rules.IsShanghai, rules.IsCancun, rules.IsPrague, rules.IsVerkle)
-	log.Debugf("sender:%v coinbase: %v dest: %v", sender, coinbase, dest)
-	log.Debugf("precompiles: %v", precompiles)
-	log.Debugf("txAccesses: %v", txAccesses)
+	// log.Debugf("Mutable - Prepare(...)")
+	// log.Debugf("ChainID:%v Homestead:%v EIP150:%v EIP155:%v EIP158:%v", rules.ChainID, rules.IsHomestead, rules.IsEIP150, rules.IsEIP155, rules.IsEIP158)
+	// log.Debugf("EIP2929:%v EIP4762:%v", rules.IsEIP2929, rules.IsEIP4762)
+	// log.Debugf("Byzantium:%v Constantinople:%v Petersburg:%v Istanbul:%v", rules.IsByzantium, rules.IsConstantinople, rules.IsPetersburg, rules.IsIstanbul)
+	// log.Debugf("Berlin:%v London:%v", rules.IsBerlin, rules.IsLondon)
+	// log.Debugf("Merge:%v Shanghai:%v Cancun:%v Prague:%v Verkle:%v", rules.IsMerge, rules.IsShanghai, rules.IsCancun, rules.IsPrague, rules.IsVerkle)
+	// log.Debugf("sender:%v coinbase: %v dest: %v", sender, coinbase, dest)
+	// log.Debugf("precompiles: %v", precompiles)
+	// log.Debugf("txAccesses: %v", txAccesses)
 
 	// Adapted from go-ethereum@v1.14.8/core/state/statedb.go
 	if rules.IsEIP2929 && rules.IsEIP4762 {
@@ -301,8 +300,8 @@ func (s *mutableStateImpl) Prepare(rules params.Rules, sender, coinbase common.A
 // exists, this function will silently overwrite it which might lead to a
 // consensus bug eventually.
 func (s *mutableStateImpl) CreateAccount(addr common.Address) {
-	log.Debugf("Mutable - CreateAccount(%v)", addr)
-	defer func() { log.Debugf("Mutable - CreateAccount(%v) returns void", addr) }()
+	// log.Debugf("Mutable - CreateAccount(%v)", addr)
+	// defer func() { log.Debugf("Mutable - CreateAccount(%v) returns void", addr) }()
 
 	acct := s.loadAccount(addr, true)
 	s.recordJournal(acct.Create())
@@ -314,8 +313,8 @@ func (s *mutableStateImpl) CreateAccount(addr common.Address) {
 // This operation sets the 'newContract'-flag, which is required in order to
 // correctly handle EIP-6780 'delete-in-same-transaction' logic.
 func (s *mutableStateImpl) CreateContract(addr common.Address) {
-	log.Debugf("Mutable - CreateContract(%v)", addr)
-	defer func() { log.Debugf("Mutable - CreateContract(%v) returns void", addr) }()
+	// log.Debugf("Mutable - CreateContract(%v)", addr)
+	// defer func() { log.Debugf("Mutable - CreateContract(%v) returns void", addr) }()
 
 	_, ok := s.NewContracts[addr]
 	if !ok {
@@ -326,8 +325,8 @@ func (s *mutableStateImpl) CreateContract(addr common.Address) {
 
 // SubBalance subtracts amount from the account associated with addr.
 func (s *mutableStateImpl) SubBalance(addr common.Address, amt *uint256.Int, reason tracing.BalanceChangeReason) {
-	log.Debugf("Mutable - SubBalance(%v, %v)", addr, amt)
-	defer func() { log.Debugf("Mutable - SubBalance(%v, %v) returns void", addr, amt) }()
+	// log.Debugf("Mutable - SubBalance(%v, %v)", addr, amt)
+	// defer func() { log.Debugf("Mutable - SubBalance(%v, %v) returns void", addr, amt) }()
 
 	acct := s.loadAccount(addr, true)
 	original := uint256.NewInt(0).Set(acct.Balance())
@@ -344,8 +343,8 @@ func (s *mutableStateImpl) SubBalance(addr common.Address, amt *uint256.Int, rea
 
 // AddBalance adds amount to the account associated with addr.
 func (s *mutableStateImpl) AddBalance(addr common.Address, amt *uint256.Int, reason tracing.BalanceChangeReason) {
-	log.Debugf("Mutable - AddBalance(%v, %v)", addr, amt)
-	defer func() { log.Debugf("Mutable - AddBalance(%v, %v) returns void", addr, amt) }()
+	// log.Debugf("Mutable - AddBalance(%v, %v)", addr, amt)
+	// defer func() { log.Debugf("Mutable - AddBalance(%v, %v) returns void", addr, amt) }()
 
 	acct := s.loadAccount(addr, true)
 	original := uint256.NewInt(0).Set(acct.Balance())
@@ -359,8 +358,8 @@ func (s *mutableStateImpl) AddBalance(addr common.Address, amt *uint256.Int, rea
 
 // SetBalance sets the balance of the account associated with addr.
 func (s *mutableStateImpl) SetBalance(addr common.Address, amt *uint256.Int, reason tracing.BalanceChangeReason) {
-	log.Debugf("Mutable - SetBalance(%v, %v)", addr, amt)
-	defer func() { log.Debugf("Mutable - SetBalance(%v, %v) returns void", addr, amt) }()
+	// log.Debugf("Mutable - SetBalance(%v, %v)", addr, amt)
+	// defer func() { log.Debugf("Mutable - SetBalance(%v, %v) returns void", addr, amt) }()
 
 	acct := s.loadAccount(addr, true)
 	original := uint256.NewInt(0).Set(acct.Balance())
@@ -374,8 +373,8 @@ func (s *mutableStateImpl) SetBalance(addr common.Address, amt *uint256.Int, rea
 
 // SetNonce sets the given nonce to the given address.
 func (s *mutableStateImpl) SetNonce(addr common.Address, nonce uint64) {
-	log.Debugf("Mutable - SetNonce(%v, %v)", addr, nonce)
-	defer func() { log.Debugf("Mutable - SetNonce(%v, %v) returns void", addr, nonce) }()
+	// log.Debugf("Mutable - SetNonce(%v, %v)", addr, nonce)
+	// defer func() { log.Debugf("Mutable - SetNonce(%v, %v) returns void", addr, nonce) }()
 
 	acct := s.loadAccount(addr, true)
 
@@ -388,8 +387,8 @@ func (s *mutableStateImpl) SetNonce(addr common.Address, nonce uint64) {
 
 // SetCode sets the code to the given address.
 func (s *mutableStateImpl) SetCode(addr common.Address, code []byte) {
-	log.Debugf("Mutable - SetCode(%v, %v)", addr, code)
-	defer func() { log.Debugf("Mutable - SetCode(%v, %v) returns void", addr, code) }()
+	// log.Debugf("Mutable - SetCode(%v, %v)", addr, code)
+	// defer func() { log.Debugf("Mutable - SetCode(%v, %v) returns void", addr, code) }()
 
 	acct := s.loadAccount(addr, true)
 
@@ -403,8 +402,8 @@ func (s *mutableStateImpl) SetCode(addr common.Address, code []byte) {
 
 // SetState sets the value associated with the specific key.
 func (s *mutableStateImpl) SetState(addr common.Address, key common.Hash, val common.Hash) {
-	log.Debugf("Mutable - SetState(%v, %v, %v)", addr, key, val)
-	defer func() { log.Debugf("Mutable - SetState(%v, %v, %v) returns void", addr, key, val) }()
+	// log.Debugf("Mutable - SetState(%v, %v, %v)", addr, key, val)
+	// defer func() { log.Debugf("Mutable - SetState(%v, %v, %v) returns void", addr, key, val) }()
 
 	acct := s.loadAccount(addr, true)
 
@@ -419,8 +418,8 @@ func (s *mutableStateImpl) SetState(addr common.Address, key common.Hash, val co
 // GetCommittedState retrieves the value associated with the specific key
 // without any mutations caused in the current execution.
 func (s *mutableStateImpl) GetCommittedState(addr common.Address, key common.Hash) (val common.Hash) {
-	log.Debugf("Mutable - GetCommittedState(%v, %v)", addr, key)
-	defer func() { log.Debugf("Mutable - GetCommittedState(%v, %v) returns %v", addr, key, val) }()
+	// log.Debugf("Mutable - GetCommittedState(%v, %v)", addr, key)
+	// defer func() { log.Debugf("Mutable - GetCommittedState(%v, %v) returns %v", addr, key, val) }()
 
 	val = s.parent.GetMutableAccount(addr).GetState(key)
 	return
@@ -428,8 +427,8 @@ func (s *mutableStateImpl) GetCommittedState(addr common.Address, key common.Has
 
 // GetTransientState gets transient storage for a given account.
 func (s *mutableStateImpl) GetTransientState(addr common.Address, key common.Hash) (val common.Hash) {
-	log.Debugf("Mutable - GetTransientState(%v, %v)", addr, key)
-	defer func() { log.Debugf("Mutable - GetTransientState(%v, %v) returns %v", addr, key, val) }()
+	// log.Debugf("Mutable - GetTransientState(%v, %v)", addr, key)
+	// defer func() { log.Debugf("Mutable - GetTransientState(%v, %v) returns %v", addr, key, val) }()
 
 	storageMap, ok := s.TransientState[addr]
 	if ok {
@@ -446,8 +445,8 @@ func (s *mutableStateImpl) GetTransientState(addr common.Address, key common.Has
 // adds the change to the journal so that it can be rolled back
 // to its previous value if there is a revert.
 func (s *mutableStateImpl) SetTransientState(addr common.Address, key common.Hash, val common.Hash) {
-	log.Debugf("Mutable - SetTransientState(%v, %v, %v)", addr, key, val)
-	defer func() { log.Debugf("Mutable - SetTransientState(%v, %v, %v) returns void", addr, key, val) }()
+	// log.Debugf("Mutable - SetTransientState(%v, %v, %v)", addr, key, val)
+	// defer func() { log.Debugf("Mutable - SetTransientState(%v, %v, %v) returns void", addr, key, val) }()
 
 	storageMap, ok := s.TransientState[addr]
 	if !ok {
@@ -467,8 +466,8 @@ func (s *mutableStateImpl) SetTransientState(addr common.Address, key common.Has
 
 // GetRefund returns the current value of the refund counter.
 func (s *mutableStateImpl) GetRefund() (refund uint64) {
-	log.Debugf("Mutable - GetRefund()")
-	defer func() { log.Debugf("Mutable - GetRefund() returns %v", refund) }()
+	// log.Debugf("Mutable - GetRefund()")
+	// defer func() { log.Debugf("Mutable - GetRefund() returns %v", refund) }()
 
 	refund = s.Refund
 	return
@@ -476,8 +475,8 @@ func (s *mutableStateImpl) GetRefund() (refund uint64) {
 
 // AddRefund adds gas to the refund counter.
 func (s *mutableStateImpl) AddRefund(gas uint64) {
-	log.Debugf("Mutable - AddRefund(%v)", gas)
-	defer func() { log.Debugf("Mutable - AddRefund(%v) returns void", gas) }()
+	// log.Debugf("Mutable - AddRefund(%v)", gas)
+	// defer func() { log.Debugf("Mutable - AddRefund(%v) returns void", gas) }()
 
 	original := s.Refund
 	s.Refund += gas
@@ -487,8 +486,8 @@ func (s *mutableStateImpl) AddRefund(gas uint64) {
 // SubRefund removes gas from the refund counter.
 // This method will panic if the refund counter goes below zero.
 func (s *mutableStateImpl) SubRefund(gas uint64) {
-	log.Debugf("Mutable - SubRefund(%v)", gas)
-	defer func() { log.Debugf("Mutable - SubRefund(%v) returns void", gas) }()
+	// log.Debugf("Mutable - SubRefund(%v)", gas)
+	// defer func() { log.Debugf("Mutable - SubRefund(%v) returns void", gas) }()
 
 	original := s.Refund
 	if s.Refund < gas {
@@ -500,8 +499,8 @@ func (s *mutableStateImpl) SubRefund(gas uint64) {
 
 // Check if given account was marked as self-destructed.
 func (s *mutableStateImpl) HasSelfDestructed(addr common.Address) (destructed bool) {
-	log.Debugf("Mutable - HasSelfDestructed(%v)", addr)
-	defer func() { log.Debugf("Mutable - HasSelfDestructed(%v) returns %v", addr, destructed) }()
+	// log.Debugf("Mutable - HasSelfDestructed(%v)", addr)
+	// defer func() { log.Debugf("Mutable - HasSelfDestructed(%v) returns %v", addr, destructed) }()
 
 	// Note: even though this is a read only query,
 	// but this account should pre exist in dirty accounts.
@@ -516,8 +515,8 @@ func (s *mutableStateImpl) HasSelfDestructed(addr common.Address) (destructed bo
 // The account's state object is still available until the state is committed,
 // getStateObject will return a non-nil account after SelfDestruct.
 func (s *mutableStateImpl) SelfDestruct(addr common.Address) {
-	log.Debugf("Mutable - SelfDestruct(%v)", addr)
-	defer func() { log.Debugf("Mutable - SelfDestruct(%v) returns void", addr) }()
+	// log.Debugf("Mutable - SelfDestruct(%v)", addr)
+	// defer func() { log.Debugf("Mutable - SelfDestruct(%v) returns void", addr) }()
 
 	acct := s.loadAccount(addr, true)
 
@@ -530,8 +529,8 @@ func (s *mutableStateImpl) SelfDestruct(addr common.Address) {
 
 // SelfDestruct given account according to EIP-6780.
 func (s *mutableStateImpl) Selfdestruct6780(addr common.Address) {
-	log.Debugf("Mutable - Selfdestruct6780(%v)", addr)
-	defer func() { log.Debugf("Mutable - Selfdestruct6780(%v) returns void", addr) }()
+	// log.Debugf("Mutable - Selfdestruct6780(%v)", addr)
+	// defer func() { log.Debugf("Mutable - Selfdestruct6780(%v) returns void", addr) }()
 
 	acct := s.loadAccount(addr, true)
 	_, ok := s.NewContracts[addr]
@@ -542,8 +541,8 @@ func (s *mutableStateImpl) Selfdestruct6780(addr common.Address) {
 
 // AddressInAccessList returns true if the given address is in the access list.
 func (s *mutableStateImpl) AddressInAccessList(addr common.Address) (ok bool) {
-	log.Debugf("Mutable - AddressInAccessList(%v)", addr)
-	defer func() { log.Debugf("Mutable - AddressInAccessList(%v) returns %v", addr, ok) }()
+	// log.Debugf("Mutable - AddressInAccessList(%v)", addr)
+	// defer func() { log.Debugf("Mutable - AddressInAccessList(%v) returns %v", addr, ok) }()
 
 	_, ok = s.AccessAddress[addr]
 	return
@@ -551,8 +550,8 @@ func (s *mutableStateImpl) AddressInAccessList(addr common.Address) (ok bool) {
 
 // AddAddressToAccessList adds the given address to the access list.
 func (s *mutableStateImpl) AddAddressToAccessList(addr common.Address) {
-	log.Debugf("Mutable - AddAddressToAccessList(%v)", addr)
-	defer func() { log.Debugf("Mutable - AddAddressToAccessList(%v) returns void", addr) }()
+	// log.Debugf("Mutable - AddAddressToAccessList(%v)", addr)
+	// defer func() { log.Debugf("Mutable - AddAddressToAccessList(%v) returns void", addr) }()
 
 	_, ok := s.AccessAddress[addr]
 	if ok {
@@ -564,8 +563,8 @@ func (s *mutableStateImpl) AddAddressToAccessList(addr common.Address) {
 
 // SlotInAccessList returns true if the given (address, slot)-tuple is in the access list.
 func (s *mutableStateImpl) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	log.Debugf("Mutable - SlotInAccessList(%v, %v)", addr, slot)
-	defer func() { log.Debugf("Mutable - SlotInAccessList(%v, %v) returns %v, %v", addr, slot, addressOk, slotOk) }()
+	// log.Debugf("Mutable - SlotInAccessList(%v, %v)", addr, slot)
+	// defer func() { log.Debugf("Mutable - SlotInAccessList(%v, %v) returns %v, %v", addr, slot, addressOk, slotOk) }()
 
 	idx, ok := s.AccessAddress[addr]
 	if !ok {
@@ -586,8 +585,8 @@ func (s *mutableStateImpl) SlotInAccessList(addr common.Address, slot common.Has
 
 // AddSlotToAccessList adds the given (address, slot)-tuple to the access list.
 func (s *mutableStateImpl) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	log.Debugf("Mutable - AddSlotToAccessList(%v, %v)", addr, slot)
-	defer func() { log.Debugf("Mutable - AddSlotToAccessList(%v, %v) returns void", addr, slot) }()
+	// log.Debugf("Mutable - AddSlotToAccessList(%v, %v)", addr, slot)
+	// defer func() { log.Debugf("Mutable - AddSlotToAccessList(%v, %v) returns void", addr, slot) }()
 
 	idx, ok := s.AccessAddress[addr]
 	if !ok {
@@ -623,13 +622,13 @@ func (s *mutableStateImpl) PointCache() *utils.PointCache {
 // GetLogs returns the logs matching the specified transaction hash, and annotates
 // them with the given blockNumber and blockHash.
 func (s *mutableStateImpl) GetLogs(hash common.Hash, blockNumber uint64, blockHash common.Hash) (logs []*types.Log) {
-	log.Debugf("Mutable - GetLogs(%v, %v, %v)", hash, blockNumber, blockHash)
+	// log.Debugf("Mutable - GetLogs(%v, %v, %v)", hash, blockNumber, blockHash)
 	defer func() {
 		str := ""
 		for _, l := range logs {
 			str += fmt.Sprintf("%v;", l)
 		}
-		log.Debugf("Mutable - GetLogs(%v, %v, %v) returns %v", hash, blockNumber, blockHash, str)
+		// log.Debugf("Mutable - GetLogs(%v, %v, %v) returns %v", hash, blockNumber, blockHash, str)
 	}()
 
 	if s.TxHash.Cmp(hash) == 0 {
@@ -647,8 +646,8 @@ func (s *mutableStateImpl) GetLogs(hash common.Hash, blockNumber uint64, blockHa
 
 // Add log adds a log to the log list.
 func (s *mutableStateImpl) AddLog(logs *types.Log) {
-	log.Debugf("Mutable - AddLog(%v)", logs)
-	defer func() { log.Debugf("Mutable - AddLog(%v) returns void", logs) }()
+	// log.Debugf("Mutable - AddLog(%v)", logs)
+	// defer func() { log.Debugf("Mutable - AddLog(%v) returns void", logs) }()
 
 	logs.TxHash = s.TxHash
 	logs.TxIndex = uint(s.TxIdx)
@@ -663,15 +662,15 @@ func (s *mutableStateImpl) AddLog(logs *types.Log) {
 
 // AddPreimage records a SHA3 preimage seen by the VM.
 func (s *mutableStateImpl) AddPreimage(key common.Hash, val []byte) {
-	log.Debugf("Mutable - AddPreimage(%v, %v)", key, hex.EncodeToString(val))
-	defer func() { log.Debugf("Mutable - AddPreimage(%v, %v) returns void", key, hex.EncodeToString(val)) }()
+	// log.Debugf("Mutable - AddPreimage(%v, %v)", key, hex.EncodeToString(val))
+	// defer func() { log.Debugf("Mutable - AddPreimage(%v, %v) returns void", key, hex.EncodeToString(val)) }()
 	// Not supported.
 }
 
 // Witness retrieves the current state witness being collected.
 func (s *mutableStateImpl) Witness() *stateless.Witness {
-	log.Debugf("Mutable - Witness()")
-	defer func() { log.Debugf("Mutable - Witness() returns nil") }()
+	// log.Debugf("Mutable - Witness()")
+	// defer func() { log.Debugf("Mutable - Witness() returns nil") }()
 
 	// Not supported.
 	return nil
@@ -679,8 +678,8 @@ func (s *mutableStateImpl) Witness() *stateless.Witness {
 
 // Snapshot returns an identifier for the current revision of the state.
 func (s *mutableStateImpl) Snapshot() (res int) {
-	log.Debugf("Mutable - Snapshot()")
-	defer func() { log.Debugf("Mutable - Snapshot() returns %v", res) }()
+	// log.Debugf("Mutable - Snapshot()")
+	// defer func() { log.Debugf("Mutable - Snapshot() returns %v", res) }()
 
 	res = s.snapshotId
 	s.snapshotId++
@@ -696,8 +695,8 @@ func (s *mutableStateImpl) Snapshot() (res int) {
 
 // RevertToSnapshot reverts all state changes made since the given revision.
 func (s *mutableStateImpl) RevertToSnapshot(ti int) {
-	log.Debugf("Mutable - RevertToSnapshot(%v)", ti)
-	defer func() { log.Debugf("Mutable - RevertToSnapshot(%v) returns void", ti) }()
+	// log.Debugf("Mutable - RevertToSnapshot(%v)", ti)
+	// defer func() { log.Debugf("Mutable - RevertToSnapshot(%v) returns void", ti) }()
 
 	for i := len(s.Journals) - 1; i >= 0; i-- {
 		entry := s.Journals[i]
@@ -721,8 +720,8 @@ func (s *mutableStateImpl) RevertToSnapshot(ti int) {
 // the journal as well as the refunds. Finalise, however, will not push any updates
 // into the tries just yet. Only IntermediateRoot or Commit will do that.
 func (s *mutableStateImpl) Finalise(deleteEmptyObjects bool) {
-	log.Debugf("Mutable - Finalise(%v)", deleteEmptyObjects)
-	defer func() { log.Debugf("Mutable - Finalise(%v) returns void", deleteEmptyObjects) }()
+	// log.Debugf("Mutable - Finalise(%v)", deleteEmptyObjects)
+	// defer func() { log.Debugf("Mutable - Finalise(%v) returns void", deleteEmptyObjects) }()
 
 	for addr, acct := range s.DirtyAccounts {
 		if deleteEmptyObjects && acct.Empty() {
@@ -749,10 +748,10 @@ func (s *mutableStateImpl) Finalise(deleteEmptyObjects bool) {
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
 func (s *mutableStateImpl) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
-	log.Debugf("Mutable - IntermediateRoot(%v)", deleteEmptyObjects)
-	defer func() {
-		log.Debugf("Mutable - IntermediateRoot(%v) returns %v", deleteEmptyObjects, types.EmptyRootHash)
-	}()
+	// log.Debugf("Mutable - IntermediateRoot(%v)", deleteEmptyObjects)
+	// defer func() {
+	// 	log.Debugf("Mutable - IntermediateRoot(%v) returns %v", deleteEmptyObjects, types.EmptyRootHash)
+	// }()
 
 	s.Finalise(deleteEmptyObjects)
 	// Not supported, so empty root hash is returned
@@ -769,10 +768,10 @@ func (s *mutableStateImpl) IntermediateRoot(deleteEmptyObjects bool) common.Hash
 // The associated block number of the state transition is also provided
 // for more chain context.
 func (s *mutableStateImpl) Commit(block uint64, rootHash common.Hash, deleteEmptyObjects bool) (res common.Hash, err error) {
-	log.Debugf("Mutable - Commit(%v, %v, %v)", block, rootHash, deleteEmptyObjects)
-	defer func() {
-		log.Debugf("Mutable - Commit(%v, %v, %v) returns (%v, %v)", block, rootHash, deleteEmptyObjects, res, err)
-	}()
+	// log.Debugf("Mutable - Commit(%v, %v, %v)", block, rootHash, deleteEmptyObjects)
+	// defer func() {
+	// 	log.Debugf("Mutable - Commit(%v, %v, %v) returns (%v, %v)", block, rootHash, deleteEmptyObjects, res, err)
+	// }()
 
 	s.IntermediateRoot(deleteEmptyObjects)
 	res, err = s.parent.Commit(block, rootHash)

--- a/worldstate/persistedstate_impl_test.go
+++ b/worldstate/persistedstate_impl_test.go
@@ -97,10 +97,6 @@ func TestGetAccountValue(t *testing.T) {
 	// Get without error
 	acct = layer.GetAccountValue(common.HexToAddress(testAcctStr), true)
 	assert.Equal(t, expectedValue, acct)
-
-	// Get with cache
-	acct = layer.GetAccountValue(common.HexToAddress(testAcctStr), true)
-	assert.Equal(t, expectedValue, acct)
 }
 
 func TestGetCodeByHash(t *testing.T) {
@@ -140,10 +136,6 @@ func TestGetCodeByHash(t *testing.T) {
 	// Get without error
 	code = layer.GetCodeByHash(common.HexToHash("0x123"), true)
 	assert.Equal(t, expectedCode, code)
-
-	// Get with cache
-	code = layer.GetCodeByHash(common.HexToHash("0x123"), true)
-	assert.Equal(t, expectedCode, code)
 }
 
 func TestGetStorageByVersion(t *testing.T) {
@@ -181,10 +173,6 @@ func TestGetStorageByVersion(t *testing.T) {
 	assert.Equal(t, common.Hash{}, val)
 
 	// Get without error
-	val = layer.GetStorageByVersion(common.HexToAddress(testAcctStr), 1, common.HexToHash("0x1"), true)
-	assert.Equal(t, expectedStorage, val)
-
-	// Get with cache
 	val = layer.GetStorageByVersion(common.HexToAddress(testAcctStr), 1, common.HexToHash("0x1"), true)
 	assert.Equal(t, expectedStorage, val)
 }

--- a/worldstate/tempcommitted_impl.go
+++ b/worldstate/tempcommitted_impl.go
@@ -65,10 +65,10 @@ func newTempCommittedState(
 
 // GetMutableAccount gets the mutable account of given address.
 func (s *tempCommittedState) GetMutableAccount(addr common.Address) (res mutableAccount) {
-	log.Debugf("Committed - GetMutableAccount(%v)", addr)
-	defer func() {
-		log.Debugf("Committed - GetMutableAccount(%v) returns (%v-%v-%v-%v-%v)", addr, res.Nonce(), res.Balance(), res.CodeHash(), res.DirtyStorage(), res.Version())
-	}()
+	// log.Debugf("Committed - GetMutableAccount(%v)", addr)
+	// defer func() {
+	// 	log.Debugf("Committed - GetMutableAccount(%v) returns (%v-%v-%v-%v-%v)", addr, res.Nonce(), res.Balance(), res.CodeHash(), res.DirtyStorage(), res.Version())
+	// }()
 
 	acct, ok := s.CommittedAccounts[addr]
 	if !ok {
@@ -96,14 +96,14 @@ func (s *tempCommittedState) GetMutableAccount(addr common.Address) (res mutable
 // GetLogs returns the logs matching the specified transaction hash, and annotates
 // them with the given blockNumber and blockHash.
 func (s *tempCommittedState) GetLogs(hash common.Hash, blockNumber uint64, blockHash common.Hash) (logs []*types.Log) {
-	log.Debugf("Committed - GetLogs(%v, %v, %v)", hash, blockNumber, blockHash)
-	defer func() {
-		str := ""
-		for _, l := range logs {
-			str += fmt.Sprintf("%v;", l)
-		}
-		log.Debugf("Committed - GetLogs(%v, %v, %v) returns %v", hash, blockNumber, blockHash, str)
-	}()
+	// log.Debugf("Committed - GetLogs(%v, %v, %v)", hash, blockNumber, blockHash)
+	// defer func() {
+	// 	str := ""
+	// 	for _, l := range logs {
+	// 		str += fmt.Sprintf("%v;", l)
+	// 	}
+	// 	log.Debugf("Committed - GetLogs(%v, %v, %v) returns %v", hash, blockNumber, blockHash, str)
+	// }()
 
 	var ok bool
 	logs, ok = s.Logs[hash]
@@ -120,8 +120,8 @@ func (s *tempCommittedState) GetLogs(hash common.Hash, blockNumber uint64, block
 
 // GetLogSize returns the size of the log.
 func (s *tempCommittedState) GetLogSize() (size uint) {
-	log.Debugf("Committed - GetLogSize()")
-	defer func() { log.Debugf("Committed - GetLogSize() returns %v", size) }()
+	// log.Debugf("Committed - GetLogSize()")
+	// defer func() { log.Debugf("Committed - GetLogSize() returns %v", size) }()
 
 	size = s.LogSize
 	return
@@ -134,8 +134,8 @@ func (s *tempCommittedState) ApplyChanges(
 	logs []*types.Log,
 	dirtyAccounts map[common.Address]mutableAccount,
 ) {
-	log.Debugf("Committed - ApplyChanges(...)")
-	defer func() { log.Debugf("Committed - ApplyChanges(...) returns void") }()
+	// log.Debugf("Committed - ApplyChanges(...)")
+	// defer func() { log.Debugf("Committed - ApplyChanges(...) returns void") }()
 
 	// Apply finalized account changes one by one
 	for addr, acct := range dirtyAccounts {
@@ -162,8 +162,8 @@ func (s *tempCommittedState) ApplyChanges(
 }
 
 func (s *tempCommittedState) Commit(block uint64, rootHash common.Hash) (res common.Hash, err error) {
-	log.Debugf("Committed - Commit(%v, %v)", block, rootHash)
-	defer func() { log.Debugf("Committed - Commit(%v, %v) returns (%v, %v)", block, rootHash, res, err) }()
+	// log.Debugf("Committed - Commit(%v, %v)", block, rootHash)
+	// defer func() { log.Debugf("Committed - Commit(%v, %v) returns (%v, %v)", block, rootHash, res, err) }()
 
 	res = common.Hash{}
 	if s.committed {

--- a/worldstate/worldstate.go
+++ b/worldstate/worldstate.go
@@ -289,8 +289,14 @@ type LayeredWorldStateArchive interface {
 	// GetChainConfig gets the chain configuration.
 	GetChainConfig() *params.ChainConfig
 
+	// SetMaxLayerToRetain sets the configured max layer to retain in memory.
+	SetMaxLayerToRetain(maxLayerToRetain uint64)
+
 	// GetMaxLayerToRetain gets the configured max layer to retain in memory.
 	GetMaxLayerToRetain() uint64
+
+	// SetPruningFrequency sets the configured pruning frequency.
+	SetPruningFrequency(pruningFrequency uint64)
 
 	// GetPruningFrequency gets the configured pruning frequency.
 	GetPruningFrequency() uint64

--- a/worldstate/worldstate_mock.go
+++ b/worldstate/worldstate_mock.go
@@ -1215,6 +1215,18 @@ func (mr *MockMutableWorldStateMockRecorder) SetCode(addr, code any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCode", reflect.TypeOf((*MockMutableWorldState)(nil).SetCode), addr, code)
 }
 
+// SetLogger mocks base method.
+func (m *MockMutableWorldState) SetLogger(l *tracing.Hooks) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLogger", l)
+}
+
+// SetLogger indicates an expected call of SetLogger.
+func (mr *MockMutableWorldStateMockRecorder) SetLogger(l any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockMutableWorldState)(nil).SetLogger), l)
+}
+
 // SetNonce mocks base method.
 func (m *MockMutableWorldState) SetNonce(addr common.Address, nonce uint64) {
 	m.ctrl.T.Helper()
@@ -1686,4 +1698,28 @@ func (m *MockLayeredWorldStateArchive) Register(height uint64, root common.Hash,
 func (mr *MockLayeredWorldStateArchiveMockRecorder) Register(height, root, worldState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockLayeredWorldStateArchive)(nil).Register), height, root, worldState)
+}
+
+// SetMaxLayerToRetain mocks base method.
+func (m *MockLayeredWorldStateArchive) SetMaxLayerToRetain(maxLayerToRetain uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxLayerToRetain", maxLayerToRetain)
+}
+
+// SetMaxLayerToRetain indicates an expected call of SetMaxLayerToRetain.
+func (mr *MockLayeredWorldStateArchiveMockRecorder) SetMaxLayerToRetain(maxLayerToRetain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxLayerToRetain", reflect.TypeOf((*MockLayeredWorldStateArchive)(nil).SetMaxLayerToRetain), maxLayerToRetain)
+}
+
+// SetPruningFrequency mocks base method.
+func (m *MockLayeredWorldStateArchive) SetPruningFrequency(pruningFrequency uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPruningFrequency", pruningFrequency)
+}
+
+// SetPruningFrequency indicates an expected call of SetPruningFrequency.
+func (mr *MockLayeredWorldStateArchiveMockRecorder) SetPruningFrequency(pruningFrequency any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPruningFrequency", reflect.TypeOf((*MockLayeredWorldStateArchive)(nil).SetPruningFrequency), pruningFrequency)
 }


### PR DESCRIPTION
1. Remove the base layer cache
2. Remove debugging loggings
3. Avoid maintaining multiple layers in forward syncing